### PR TITLE
add image pull secrets for db

### DIFF
--- a/k8s/was-post.yml
+++ b/k8s/was-post.yml
@@ -107,6 +107,8 @@ spec:
         volumeMounts:
             - name: mysql-persistent-storage
               mountPath: /var/lib/mysql
+      imagePullSecrets:
+        - name: regcred
       volumes:
         - name: mysql-persistent-storage
           persistentVolumeClaim:

--- a/k8s/was-survey.yml
+++ b/k8s/was-survey.yml
@@ -141,6 +141,8 @@ spec:
         volumeMounts:
             - name: mongo-persistent-storage
               mountPath: /data/db
+      imagePullSecrets:
+        - name: regcred
       volumes:
         - name: mongo-persistent-storage
           persistentVolumeClaim:

--- a/k8s/was-user.yml
+++ b/k8s/was-user.yml
@@ -109,6 +109,8 @@ spec:
         volumeMounts:
             - name: mysql-persistent-storage
               mountPath: /var/lib/mysql
+      imagePullSecrets:
+        - name: regcred
       volumes:
         - name: mysql-persistent-storage
           persistentVolumeClaim:


### PR DESCRIPTION
add image pull secrets for db
When pulling a db image, authentication can be used to mitigate restrictions such as pull limits.